### PR TITLE
Feature/fix rspec deprecation warnings

### DIFF
--- a/spec/mapbox/abstract_marker_spec.rb
+++ b/spec/mapbox/abstract_marker_spec.rb
@@ -12,32 +12,43 @@ describe AbstractMarker do
     end
   end
 
-  context "mixed bag of mapbox options to test validation" do  
-    subject(:marker){ Marker.new(lat, lon,) }
-    let(:lat){ "12.34567" }
-    let(:lon){ 123.45678 }
+  context 'mixed bag of mapbox options to test validation' do
+    subject(:marker) { Marker.new(lat, lon) }
+    let(:lat) { '12.34567' }
+    let(:lon) { 123.45678 }
 
-    its(:lat){ should == 12.34567 }
-    its(:lon){ should == 123.45678 }
-    its(:to_s){ should == "(123.45678,12.34567)" }
+    describe '#lat' do
+      subject { super().lat }
+      it { should == 12.34567 }
+    end
 
-    it "should throw an exception if the latitude is malformed." do
+    describe '#lon' do
+      subject { super().lon }
+      it { should == 123.45678 }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == '(123.45678,12.34567)' }
+    end
+
+    it 'should throw an exception if the latitude is malformed.' do
       expect{ subject.latitude = 1337 }.to raise_error(ArgumentError)
       expect{ subject.latitude = 86 }.to raise_error(ArgumentError)
       expect{ subject.latitude = -85.000001 }.to raise_error(ArgumentError)
     end
 
-    it "should throw an exception if the longitude is malformed." do
+    it 'should throw an exception if the longitude is malformed.' do
       expect{ subject.longitude = 1337 }.to raise_error(ArgumentError)
       expect{ subject.longitude = -181 }.to raise_error(ArgumentError)
       expect{ subject.longitude = 180.000001 }.to raise_error(ArgumentError)
     end
   end
 
-  context "AbstractMarker class" do
+  context 'AbstractMarker class' do
     subject(:klass) { AbstractMarker }
 
-    it "define constanst for pin sizes" do 
+    it 'define constanst for pin sizes' do
       expect{ subject.new }.to raise_error(RuntimeError)
     end
   end

--- a/spec/mapbox/custom_marker_spec.rb
+++ b/spec/mapbox/custom_marker_spec.rb
@@ -5,27 +5,41 @@ require 'mapbox'
 #pin-s-park+cc4422(-77,38)
 
 describe CustomMarker do
-  subject(:marker){ CustomMarker.new(lat, lon, url) }
+  subject(:marker) { CustomMarker.new(lat, lon, url) }
 
-  let(:lat){ 38 }
-  let(:lon){ -77 }
-  let(:url){ "http://bit.ly/KahHBj" }
+  let(:lat) { 38 }
+  let(:lon) { -77 }
+  let(:url) { 'http://bit.ly/KahHBj' }
 
-  # Thes examples come from the MaxBox developer documentation and will be maintained
+  # These examples come from the MaxBox developer documentation and will be maintained
   # to match the documentation. if matching the docs causes a fail we need to look
   # if the format has changed.
 
-  context "with external marker image at :url" do
-    its(:url){ should == "bit.ly%2FKahHBj" }
-    its(:to_s){ should == "url-bit.ly%2FKahHBj(-77.0,38.0)" }
+  context 'with external marker image at :url' do
+    describe '#url' do
+      subject { super().url }
+      it { should == 'bit.ly%2FKahHBj' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'url-bit.ly%2FKahHBj(-77.0,38.0)' }
+    end
   end
 
   # These examples test some edge cases and input variations
 
-  context "mixed bag of mapbox options to test validation" do
-    let(:url){ "m.anml.io/image/1233456" }
+  context 'mixed bag of mapbox options to test validation' do
+    let(:url) { 'm.anml.io/image/1233456' }
 
-    its(:url){ should == "m.anml.io%2Fimage%2F1233456" }
-    its(:to_s){ should == "url-m.anml.io%2Fimage%2F1233456(-77.0,38.0)" }
+    describe '#url' do
+      subject { super().url }
+      it { should == 'm.anml.io%2Fimage%2F1233456' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'url-m.anml.io%2Fimage%2F1233456(-77.0,38.0)' }
+    end
   end
 end

--- a/spec/mapbox/mapbox_marker_spec.rb
+++ b/spec/mapbox/mapbox_marker_spec.rb
@@ -200,9 +200,9 @@ describe MapboxMarker do
     end
 
     it 'define constanst for pin sizes' do
-      MapboxMarker::SMALL_PIN.should == 'pin-s'
-      MapboxMarker::MEDIUM_PIN.should == 'pin-m'
-      MapboxMarker::LARGE_PIN.should == 'pin-l'
+      expect(MapboxMarker::SMALL_PIN).to eq('pin-s')
+      expect(MapboxMarker::MEDIUM_PIN).to eq('pin-m')
+      expect(MapboxMarker::LARGE_PIN).to eq('pin-l')
     end
   end
 end

--- a/spec/mapbox/mapbox_marker_spec.rb
+++ b/spec/mapbox/mapbox_marker_spec.rb
@@ -5,122 +5,204 @@ require 'mapbox'
 #pin-s-park+cc4422(-77,38)
 
 describe MapboxMarker do
-  subject(:marker){ MapboxMarker.new(lat, lon, size) }
+  subject(:marker) { MapboxMarker.new(lat, lon, size) }
 
-  let(:lat){ 38 }
-  let(:lon){ -77 }
-  let(:size){ MapboxMarker::SMALL_PIN }
-  let(:color){ "cc4400" }
-  let(:label){ "fire-station" }
+  let(:lat) { 38 }
+  let(:lon) { -77 }
+  let(:size) { MapboxMarker::SMALL_PIN }
+  let(:color) { 'cc4400' }
+  let(:label) { 'fire-station' }
 
   # Thes examples come from the MaxBox developer documentation and will be maintained
   # to match the documentation. if matching the docs causes a fail we need to look
   # if the format has changed.
 
-  context "with color as an RGB hex color" do
-    subject(:marker){ MapboxMarker.new(lat, lon, size, label, color) }
-    let(:label){ "park" }
-    let(:color){ "cc4422" }
+  context 'with color as an RGB hex color' do
+    subject(:marker) { MapboxMarker.new(lat, lon, size, label, color) }
+    let(:label) { 'park' }
+    let(:color) { 'cc4422' }
 
-    its(:to_s){ should == "pin-s-park+cc4422(-77.0,38.0)" }
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'pin-s-park+cc4422(-77.0,38.0)' }
+    end
   end
 
-  context "with a pin, small" do
-    let(:size){ MapboxMarker::SMALL_PIN }
+  context 'with a pin, small' do
+    let(:size) { MapboxMarker::SMALL_PIN }
 
-    its(:name){ should == "pin-s" }
-    its(:to_s){ should == "pin-s(-77.0,38.0)" }
+    describe '#name' do
+      subject { super().name }
+      it { should == 'pin-s' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'pin-s(-77.0,38.0)' }
+    end
   end
 
-  context "with a pin, medium" do
-    let(:size){ MapboxMarker::MEDIUM_PIN }
+  context 'with a pin, medium' do
+    let(:size) { MapboxMarker::MEDIUM_PIN }
 
-    its(:name){ should == "pin-m" }
-    its(:to_s){ should == "pin-m(-77.0,38.0)" }
+    describe '#name' do
+      subject { super().name }
+      it { should == 'pin-m' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'pin-m(-77.0,38.0)' }
+    end
   end
 
-  context "with a pin, large" do
-    let(:size){ MapboxMarker::LARGE_PIN }
+  context 'with a pin, large' do
+    let(:size) { MapboxMarker::LARGE_PIN }
 
-    its(:name){ should == "pin-l" }
-    its(:to_s){ should == "pin-l(-77.0,38.0)" }
+    describe '#name' do
+      subject { super().name }
+      it { should == 'pin-l' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'pin-l(-77.0,38.0)' }
+    end
   end
 
-  context "with a label as one of the letters from A through Z" do
-    subject(:marker){ MapboxMarker.new(lat, lon, size, label) }
-    let(:label){ "a" }
+  context 'with a label as one of the letters from A through Z' do
+    subject(:marker) { MapboxMarker.new(lat, lon, size, label) }
+    let(:label) { 'a' }
 
-    its(:label){ should == "a" }
-    its(:to_s){ should == "pin-s-a(-77.0,38.0)" }
+    describe '#label' do
+      subject { super().label }
+      it { should == 'a' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'pin-s-a(-77.0,38.0)' }
+    end
   end
 
-  context "with a label as one of the digits from 0 through 9 " do
-    subject(:marker){ MapboxMarker.new(lat, lon, size, label) }
-    let(:label){ 5 }
+  context 'with a label as one of the digits from 0 through 9' do
+    subject(:marker) { MapboxMarker.new(lat, lon, size, label) }
+    let(:label) { 5 }
 
-    its(:label){ should == "5" }
-    its(:to_s){ should == "pin-s-5(-77.0,38.0)" }
+    describe '#label' do
+      subject { super().label }
+      it { should == '5' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'pin-s-5(-77.0,38.0)' }
+    end
   end
 
-  context "with a label as a Maki icon id" do
-    subject(:marker){ MapboxMarker.new(lat, lon, size, label) }
+  context 'with a label as a Maki icon id' do
+    subject(:marker) { MapboxMarker.new(lat, lon, size, label) }
 
-    its(:label){ should == "fire-station" }
-    its(:to_s){ should == "pin-s-fire-station(-77.0,38.0)" }
+    describe '#label' do
+      subject { super().label }
+      it { should == 'fire-station' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'pin-s-fire-station(-77.0,38.0)' }
+    end
   end
 
-  context "with color as an RGB hex color" do
-    subject(:marker){ MapboxMarker.new(lat, lon, size, label, color) }
+  context 'with color as an RGB hex color' do
+    subject(:marker) { MapboxMarker.new(lat, lon, size, label, color) }
 
-    its(:color){ should == "cc4400" }
-    its(:to_s){ should == "pin-s-fire-station+cc4400(-77.0,38.0)" }
+    describe '#color' do
+      subject { super().color }
+      it { should == 'cc4400' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'pin-s-fire-station+cc4400(-77.0,38.0)' }
+    end
   end
 
   # These examples test some edge cases and input variations
 
-  context "mixed bag of mapbox options to test validation" do     
-    subject(:marker){ MapboxMarker.new("12.34567", 123.45678, MapboxMarker.size[:medium], "a", "#9900cc") }
+  context 'mixed bag of mapbox options to test validation' do
+    subject(:marker){ MapboxMarker.new('12.34567', 123.45678, MapboxMarker.size[:medium], 'a', '#9900cc') }
 
-    its(:name){ should == MapboxMarker::MEDIUM_PIN }
-    its(:size){ should == "pin-m" }
-    its(:lat){ should == 12.34567 }
-    its(:lon){ should == 123.45678 }
-    its(:label){ should == "a" }
-    its(:color){ should == "9900cc" }
-
-    its(:to_s){ should == "pin-m-a+9900cc(123.45678,12.34567)" }
-
-    it "should throw an exception if the color is not correctly formatted." do
-      expect{ subject.color = "hahhah" }.to raise_error(ArgumentError)
+    describe '#name' do
+      subject { super().name }
+      it { should == MapboxMarker::MEDIUM_PIN }
     end
 
-    it "should throw an exception if the label is malformed." do
+    describe '#size' do
+      subject { super().size }
+      it { should == 'pin-m' }
+    end
+
+    describe '#lat' do
+      subject { super().lat }
+      it { should == 12.34567 }
+    end
+
+    describe '#lon' do
+      subject { super().lon }
+      it { should == 123.45678 }
+    end
+
+    describe '#label' do
+      subject { super().label }
+      it { should == 'a' }
+    end
+
+    describe '#color' do
+      subject { super().color }
+      it { should == '9900cc' }
+    end
+
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'pin-m-a+9900cc(123.45678,12.34567)' }
+    end
+
+    it 'should throw an exception if the color is not correctly formatted' do
+      expect{ subject.color = 'hahhah' }.to raise_error(ArgumentError)
+    end
+
+    it 'should throw an exception if the label is malformed' do
       expect{ subject.label = 10 }.to raise_error(ArgumentError)
-      expect{ subject.label = "10" }.to raise_error(ArgumentError)
-      expect{ subject.label = "AA" }.to raise_error(ArgumentError)
-      expect{ subject.label = "q" }.to_not raise_error(ArgumentError)
+      expect{ subject.label = '10' }.to raise_error(ArgumentError)
+      expect{ subject.label = 'AA' }.to raise_error(ArgumentError)
+      expect{ subject.label = 'q' }.to_not raise_error(ArgumentError)
       expect{ subject.label = 5 }.to_not raise_error(ArgumentError)
     end
 
-    it "should throw an exception if the label is not a maki-icon." do
-      expect{ subject.label = "wilbert" }.to raise_error(ArgumentError)
-      expect{ subject.label = "religious-agnostic" }.to raise_error(ArgumentError)
-      expect{ subject.label = "cricket" }.to_not raise_error(ArgumentError)
+    it 'should throw an exception if the label is not a maki-icon' do
+      expect{ subject.label = 'wilbert' }.to raise_error(ArgumentError)
+      expect{ subject.label = 'religious-agnostic' }.to raise_error(ArgumentError)
+      expect{ subject.label = 'cricket' }.to_not raise_error(ArgumentError)
     end
   end
 
-  context "MapboxMarker class" do
+  context 'MapboxMarker class' do
     subject(:klass) { MapboxMarker }
 
-    its(:maki_icons){ should include("wetland") }
-    its(:maki_icons){ should include("zoo") }
-    its(:maki_icons){ should include("circle-stroked") }
-    its(:maki_icons){ should_not include("dangerous") }
+    describe '#maki_icons' do
+      subject { super().maki_icons }
 
-    it "define constanst for pin sizes" do 
-      MapboxMarker::SMALL_PIN.should == "pin-s"
-      MapboxMarker::MEDIUM_PIN.should == "pin-m"
-      MapboxMarker::LARGE_PIN.should == "pin-l"
+      it { should include('wetland') }
+      it { should include('zoo') }
+      it { should include('circle-stroked') }
+      it { should_not include('dangerous') }
+    end
+
+    it 'define constanst for pin sizes' do
+      MapboxMarker::SMALL_PIN.should == 'pin-s'
+      MapboxMarker::MEDIUM_PIN.should == 'pin-m'
+      MapboxMarker::LARGE_PIN.should == 'pin-l'
     end
   end
 end

--- a/spec/mapbox/mapbox_marker_spec.rb
+++ b/spec/mapbox/mapbox_marker_spec.rb
@@ -176,14 +176,14 @@ describe MapboxMarker do
       expect{ subject.label = 10 }.to raise_error(ArgumentError)
       expect{ subject.label = '10' }.to raise_error(ArgumentError)
       expect{ subject.label = 'AA' }.to raise_error(ArgumentError)
-      expect{ subject.label = 'q' }.to_not raise_error(ArgumentError)
-      expect{ subject.label = 5 }.to_not raise_error(ArgumentError)
+      expect{ subject.label = 'q' }.to_not raise_error
+      expect{ subject.label = 5 }.to_not raise_error
     end
 
     it 'should throw an exception if the label is not a maki-icon' do
       expect{ subject.label = 'wilbert' }.to raise_error(ArgumentError)
       expect{ subject.label = 'religious-agnostic' }.to raise_error(ArgumentError)
-      expect{ subject.label = 'cricket' }.to_not raise_error(ArgumentError)
+      expect{ subject.label = 'cricket' }.to_not raise_error
     end
   end
 

--- a/spec/mapbox/static_map_spec.rb
+++ b/spec/mapbox/static_map_spec.rb
@@ -123,8 +123,8 @@ describe StaticMap do
     it 'should throw an exception if the zoom is malformed' do
       expect{ subject.zoom = -1 }.to raise_error(ArgumentError)
       expect{ subject.zoom = 23 }.to raise_error(ArgumentError)
-      expect{ subject.zoom = 22 }.not_to raise_error(ArgumentError)
-      expect{ subject.zoom = 0 }.not_to raise_error(ArgumentError)
+      expect{ subject.zoom = 22 }.not_to raise_error
+      expect{ subject.zoom = 0 }.not_to raise_error
     end
   end
 end

--- a/spec/mapbox/static_map_spec.rb
+++ b/spec/mapbox/static_map_spec.rb
@@ -9,49 +9,66 @@ require 'mapbox'
 # api.tiles.mapbox.com/v3/examples.map-4l7djmvo/pin-m-monument(-77.04,38.89)/-77.04,38.89,13/400x300.png
 
 describe StaticMap do
-  subject(:map){ StaticMap.new(lat, lon, zoom, width, height, api_id) }
-  let(:lat){38.89}
-  let(:lon){-77.04}
-  let(:zoom){13}
-  let(:width){400}
-  let(:height){300}
-  let(:api_id){"examples.map-4l7djmvo"}
+  subject(:map) { StaticMap.new(lat, lon, zoom, width, height, api_id) }
+  let(:lat) {38.89}
+  let(:lon) {-77.04}
+  let(:zoom) {13}
+  let(:width) {400}
+  let(:height) {300}
+  let(:api_id) {'examples.map-4l7djmvo'}
+
   before do
     StaticMap.api_path = nil # clear out the cache
   end
 
-  context "static image for :map" do
-    subject(:map){ StaticMap.new(lat, lon, zoom, width, height, api_id, markers) }
+  context 'static image for :map' do
+    subject(:map) { StaticMap.new(lat, lon, zoom, width, height, api_id, markers) }
     let(:expected_version) { 3 }
     let(:expected_base_url) { "api.tiles.mapbox.com/v#{expected_version}/examples.map-4l7djmvo/pin-m-monument(-77.04,38.89)/-77.04,38.89,13/400x300.png" }
-    let(:markers){ [MapboxMarker.new(38.89,-77.04,MapboxMarker::MEDIUM_PIN,"monument")] }
+    let(:markers){ [MapboxMarker.new(38.89,-77.04, MapboxMarker::MEDIUM_PIN, 'monument')] }
     let(:token) { 'pk.RtaW4iLCJhIjoid1ZLYXc2WSJ9.3K_mHa' }
 
-    its(:to_s) { should == expected_base_url }
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == expected_base_url }
+    end
+
     context 'extra params' do
       before do
         map.params = { foo: 'hello world' }
       end
-      its(:to_s) { should == expected_base_url+'?foo=hello+world' }
+
+      describe '#to_s' do
+        subject { super().to_s }
+        it { should == "#{expected_base_url}?foo=hello+world" }
+      end
     end
+
     context 'default v4 params' do
       let(:expected_version) { 4 }
+
       before do
         allow(ENV).to receive(:[]).with('MAPBOX_API_PATH').and_return nil
         allow(ENV).to receive(:[]).with('MAPBOX_ACCESS_TOKEN').and_return token
       end
-      its(:to_s) { should == "#{expected_base_url}?access_token=#{token}" }
+
+      describe '#to_s' do
+        subject { super().to_s }
+        it { should == "#{expected_base_url}?access_token=#{token}" }
+      end
     end
   end
 
-  context "Static image for :map with :markers" do
-    its(:to_s){should == "api.tiles.mapbox.com/v3/examples.map-4l7djmvo/-77.04,38.89,13/400x300.png" }
+  context 'Static image for :map with :markers' do
+    describe '#to_s' do
+      subject { super().to_s }
+      it { should == 'api.tiles.mapbox.com/v3/examples.map-4l7djmvo/-77.04,38.89,13/400x300.png' }
+    end
 
-    it "should add markers to itself" do
-      subject << MapboxMarker.new(38.89,-77.04,MapboxMarker::MEDIUM_PIN,"monument")
+    it 'should add markers to itself' do
+      subject << MapboxMarker.new(38.89,-77.04, MapboxMarker::MEDIUM_PIN, 'monument')
 
-      subject.to_s.should == 
-        "api.tiles.mapbox.com/v3/examples.map-4l7djmvo/pin-m-monument(-77.04,38.89)/-77.04,38.89,13/400x300.png"
+      subject.to_s.should == 'api.tiles.mapbox.com/v3/examples.map-4l7djmvo/pin-m-monument(-77.04,38.89)/-77.04,38.89,13/400x300.png'
     end
   end
 
@@ -66,40 +83,44 @@ describe StaticMap do
       before do
         allow(ENV).to receive(:[]).with('MAPBOX_API_PATH').and_return api_path
       end
+
       context 'MAPBOX_API_PATH environment variable' do
         let(:api_path) { 'my.custom.host/version' }
+
         it { should == api_path }
       end
 
       context 'MAPBOX_ACCESS_TOKEN environment variable' do
         let(:token) { 'eea3d0b84.134ce8bf75' }
         let(:api_path) { nil }
+
         before do
           allow(ENV).to receive(:[]).with('MAPBOX_ACCESS_TOKEN').and_return token
         end
+
         it { should == 'api.tiles.mapbox.com/v4' }
       end
     end
   end
 
-  context "Testing input validation" do
-    it "should throw an exception without an api_id." do
+  context 'Testing input validation' do
+    it 'should throw an exception without an api_id' do
       expect{ subject.api_id = nil }.to raise_error(ArgumentError)
     end
 
-    it "should throw an exception if the latitude is malformed." do
+    it 'should throw an exception if the latitude is malformed' do
       expect{ subject.latitude = 1337 }.to raise_error(ArgumentError)
       expect{ subject.latitude = 86 }.to raise_error(ArgumentError)
       expect{ subject.latitude = -85.000001 }.to raise_error(ArgumentError)
     end
 
-    it "should throw an exception if the longitude is malformed." do
+    it 'should throw an exception if the longitude is malformed' do
       expect{ subject.longitude = 1337 }.to raise_error(ArgumentError)
       expect{ subject.longitude = -181 }.to raise_error(ArgumentError)
       expect{ subject.longitude = 180.000001 }.to raise_error(ArgumentError)
     end
 
-    it "should throw an exception if the zoom is malformed." do
+    it 'should throw an exception if the zoom is malformed' do
       expect{ subject.zoom = -1 }.to raise_error(ArgumentError)
       expect{ subject.zoom = 23 }.to raise_error(ArgumentError)
       expect{ subject.zoom = 22 }.not_to raise_error(ArgumentError)

--- a/spec/mapbox/static_map_spec.rb
+++ b/spec/mapbox/static_map_spec.rb
@@ -68,7 +68,7 @@ describe StaticMap do
     it 'should add markers to itself' do
       subject << MapboxMarker.new(38.89,-77.04, MapboxMarker::MEDIUM_PIN, 'monument')
 
-      subject.to_s.should == 'api.tiles.mapbox.com/v3/examples.map-4l7djmvo/pin-m-monument(-77.04,38.89)/-77.04,38.89,13/400x300.png'
+      expect(subject.to_s).to eq('api.tiles.mapbox.com/v3/examples.map-4l7djmvo/pin-m-monument(-77.04,38.89)/-77.04,38.89,13/400x300.png')
     end
   end
 


### PR DESCRIPTION
I fixed all specs so they don't throw warnings in RSpec 2.99 anymore.
